### PR TITLE
Use facebook-android-sdk:4.37.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Evan Chu's Changes
 * Changes are committed to coleman-dev2 branch, which is based on Facebook's tag 0.7.0.
 * Add more header-search paths to ios/RCTFBSDK.xcodeproj/ in order to compile this SDK for my project.
+* Use facebook-android-sdk:4.37.0 to fix a compilation error in Facebook's React Native SDK.
 
 # React Native FBSDK
 React Native FBSDK is a wrapper around the iOS Facebook SDK and Android Facebook SDK, allowing for Facebook integration in [React Native](https://facebook.github.io/react-native/) apps. Access to native components, from login to sharing, is provided entirely through documented JavaScript modules so you don't have to call a single native function directly.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,7 @@ android {
 dependencies {
     compile 'com.android.support:appcompat-v7:27.0.2'
     compile 'com.facebook.react:react-native:+' // support react-native-v0.22-rc+
-    compile 'com.facebook.android:facebook-android-sdk:4.+'
+    compile 'com.facebook.android:facebook-android-sdk:4.37.0'
 }
 
 repositories {


### PR DESCRIPTION
According to https://developers.facebook.com/support/bugs/260814197942050/

facebook-android-sdk:4.38.0 breaks Facebook's React Native SDK. This
solution was offered in above bug report.